### PR TITLE
Extensible meta values via option

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,6 +236,11 @@ function logger(options) {
               if (filteredBody) meta.req.body = filteredBody;
 
               meta.responseTime = res.responseTime;
+              
+              // Check if meta is an object and extend meta with custom fields
+              if (typeof options.meta === "object") {
+                  _.extend(meta, options.meta);
+              }
             }
 
             if(options.expressFormat) {


### PR DESCRIPTION
We have found it valuable to be able to extend the meta values that are sent with a log message.

This patch provides the ability to extend meta values with options.meta as an object instead of a boolean.

This could also be performed with a new option, but this is a relatively non-invasive manner in which this can be done.
